### PR TITLE
Filter _build from initial copy, delete tree after generating editions

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,11 +3,13 @@ import shutil
 import sys
 from argparse import ArgumentParser
 from pathlib import Path
-from shutil import copytree, ignore_patterns
+from shutil import copytree, ignore_patterns, rmtree
 from subprocess import run
 
 from yaml import Loader, dump, load
 
+
+IGNORE_BUILD_PATTERN = ignore_patterns('_build')
 
 def get_toc_and_profiles(book_path):
     """Get the contents of _toc.yml and profiles.yml."""
@@ -34,7 +36,7 @@ def build(book_path):
         editions_path.mkdir(parents=True, exist_ok=True)
 
         # Copy the whole book
-        copytree(book_path, new_path, dirs_exist_ok=True, ignore=ignore_patterns('_build'))
+        copytree(book_path, new_path, dirs_exist_ok=True, ignore=IGNORE_BUILD_PATTERN)
 
         with open(new_path / "_toc.yml", "w") as f:
             # Overwrite the _toc.yml
@@ -52,7 +54,7 @@ def build(book_path):
             new_path / "_build/html", editions_path / profile_name, dirs_exist_ok=True
         )
 
-        shutil.rmtree(new_path)
+        rmtree(new_path)
 
 
 def main(args):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,10 +2,11 @@
 import unittest
 from pathlib import Path
 from unittest import mock
+from shutil import ignore_patterns
 
 from yaml import Loader, load
 
-from main import build, generate_tocs, get_toc_and_profiles, main, mask_parts, mask_toc
+from main import build, generate_tocs, get_toc_and_profiles, main, mask_parts, mask_toc, IGNORE_BUILD_PATTERN
 
 
 class TestMain(unittest.TestCase):
@@ -202,16 +203,17 @@ class TestBuild(unittest.TestCase):
                 mock_generate.return_value = [("dsg", {"new": "toc"})]
 
                 with mock.patch("main.copytree") as mock_copy:
-
                     with mock.patch("main.open") as mock_open:
-
                         with mock.patch("main.dump") as mock_dump:
-
                             with mock.patch("main.run") as mock_run:
-
                                 with mock.patch("main.Path.mkdir") as mock_mkdir:
+                                    with mock.patch("main.rmtree") as mock_rm:
 
-                                    build(Path("mybook"))
+                                        build(Path("mybook"))
+
+                                        mock_rm.assert_called_once_with(
+                                            Path("mybook_dsg")
+                                        )
 
                                     mock_mkdir.assert_called_once_with(
                                         parents=True, exist_ok=True
@@ -229,10 +231,11 @@ class TestBuild(unittest.TestCase):
 
                         mock_open.assert_called_with(Path("mybook_dsg/_toc.yml"), "w")
 
+                    # ignore_build_pattern = ignore_patterns("_build")
                     mock_copy.assert_has_calls(
                         [
                             mock.call(
-                                Path("mybook"), Path("mybook_dsg"), dirs_exist_ok=True
+                                Path("mybook"), Path("mybook_dsg"), dirs_exist_ok=True, ignore=IGNORE_BUILD_PATTERN
                             ),
                             mock.call(
                                 Path("mybook_dsg/_build/html"),


### PR DESCRIPTION
1. Does not copy _build files from main to each edition
2. Deletes edition source files after html files have been copied to main