### PR TITLE
Making the chapters less confusing for users who are exploring a single profile

### DIFF
--- a/master/_static/script.js
+++ b/master/_static/script.js
@@ -1,0 +1,42 @@
+document.addEventListener("DOMContentLoaded", function () {
+    let pathwayValue = sessionStorage.getItem("pathwayValue") || null;
+
+    document.addEventListener('click', function (event) {
+        const card = event.target.closest('.card-text .sphinx-bs');
+        if (card) {
+            pathwayValue = card.textContent.trim();
+            sessionStorage.setItem("pathwayValue", pathwayValue);
+        }
+
+        const link = event.target.closest('.bd-links');
+        if (link) {
+            pathwayValue = null;
+            sessionStorage.setItem("pathwayValue", null);
+        }
+    });
+
+    const images = document.querySelectorAll('img[src^="https://img.shields.io/static/v1?label=pathway"]');
+    let colour = "blue";
+    if (pathwayValue === "Data Study Group") {
+        colour = "white";
+    } else if (pathwayValue === "Phd Students") {
+        colour = "blue";
+    } else if (pathwayValue === "Group Leaders") {
+        colour = "purple";
+    } else {
+        colour = "green";
+    }
+
+
+    if (pathwayValue !== "null") {
+        for (let i = 0; i < images.length; i++) {
+            if (i === 0) {
+                images[i].setAttribute('src', `https://img.shields.io/static/v1?label=pathway&message=${pathwayValue}&color=${colour}`);
+            } else {
+                images[i].remove();
+            }
+        }
+    }
+});
+
+

--- a/master/_toc.yml
+++ b/master/_toc.yml
@@ -10,7 +10,7 @@
 # ===== Main Landing Page ========================================
 
 format: jb-book
-root: welcome
+root: index
 parts:
 - chapters:
 

--- a/master/_tocOLD.yml
+++ b/master/_tocOLD.yml
@@ -10,7 +10,7 @@
 # ===== Main Landing Page ========================================
 
 format: jb-book
-root: welcome
+root: index
 parts:
 - chapters:
 # ===== Guide for Reproducible Research ========================================

--- a/master/index.md
+++ b/master/index.md
@@ -1,0 +1,315 @@
+(welcome)=
+# Welcome
+
+*Welcome to The Turing Way handbook to reproducible, ethical and collaborative data science.*
+
+_The Turing Way_ project is open source, open collaboration, and community-driven.
+We involve and support a diverse community of contributors to make data science accessible, comprehensible and effective for everyone.
+Our goal is to provide all the information that researchers and data scientists in academia, industry and the public sector need to ensure that the projects they work on are easy to reproduce and reuse.
+
+```{admonition} Top Tip
+:class: tip
+_The Turing Way_ is not meant to be read from start to finish.
+Start with a concept, tool or method that you need now, in your current work.
+Browse the different guides that make up the book, or use the search box to search for whatever you would like to learn about first.
+```
+
+All stakeholders, including researchers, software engineers, project leaders and funding teams, are encouraged to use _The Turing Way_ to understand their roles and responsibility of reproducibility in data science.
+You can inspect our resources on [GitHub](https://github.com/alan-turing-institute/the-turing-way), contribute to the project as described in our [contribution guidelines](https://github.com/alan-turing-institute/the-turing-way/blob/master/CONTRIBUTING.md) and re-use all materials ([see the License](https://github.com/alan-turing-institute/the-turing-way/blob/master/LICENSE.md)).
+
+```{figure} figures/welcome.jpg
+---
+name: welcome-image
+alt: The Turing Way project is illustrated as a road or path with shops for different data science skills. People can go in and out with their shopping cart and pick and choose what they need.
+---
+_The Turing Way_ project illustration by Scriberia. Zenodo. [http://doi.org/10.5281/zenodo.3332807](http://doi.org/10.5281/zenodo.3332807)
+```
+
+## Different Pathways
+:::{panels}
+:container: +full-width
+:column: col-lg-6 px-2 py-2
+:header: text-center bg-white
+:card: text-left shadow
+:footer: text-left
+```{link-button} ./data-study-group.html
+:text: Data Study Group
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](reproducible-research/reproducible-research)
+- [](reproducible-research/overview)
+- [](reproducible-research/overview/overview-resources)
+
+And more... 
+
+---
+```{link-button} ./phd-students.html
+:text: PhD Students
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](communication/communication)
+- [](communication/comms-overview)
+- [](communication/comms-overview/comms-overview-principles)
+
+And more... 
+
+---
+```{link-button} ./group-leaders.html
+:text: Group Leaders
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](project-design/project-design)
+- [](project-design/pd-overview)
+- [](project-design/pd-overview/pd-overview-planning)
+
+And more... 
+
+---
+```{link-button} ./life-scientists.html
+:text: Life Scientists
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](reproducible-research/reproducible-research)
+- [](reproducible-research/overview)
+- [](reproducible-research/overview/overview-benefit)
+
+And more... 
+
+::: 
+
+:::{panels}
+:container: +full-width
+:column: col-lg-6 px-2 py-2
+:header: text-center bg-white
+:card: text-left shadow
+:footer: text-left
+```{link-button} ./data-study-group.html
+:text: Data Study Group
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](reproducible-research/reproducible-research)
+- [](reproducible-research/overview)
+- [](reproducible-research/overview/overview-resources)
+
+And more... 
+
+---
+```{link-button} ./phd-students.html
+:text: PhD Students
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](communication/communication)
+- [](communication/comms-overview)
+- [](communication/comms-overview/comms-overview-principles)
+
+And more... 
+
+---
+```{link-button} ./group-leaders.html
+:text: Group Leaders
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](project-design/project-design)
+- [](project-design/pd-overview)
+- [](project-design/pd-overview/pd-overview-planning)
+
+And more... 
+
+---
+```{link-button} ./life-scientists.html
+:text: Life Scientists
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](reproducible-research/reproducible-research)
+- [](reproducible-research/overview)
+- [](reproducible-research/overview/overview-benefit)
+
+And more... 
+
+::: 
+
+:::{panels}
+:container: +full-width
+:column: col-lg-6 px-2 py-2
+:header: text-center bg-white
+:card: text-left shadow
+:footer: text-left
+```{link-button} ./data-study-group.html
+:text: Data Study Group
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](reproducible-research/reproducible-research)
+- [](reproducible-research/overview)
+- [](reproducible-research/overview/overview-resources)
+
+And more... 
+
+---
+```{link-button} ./phd-students.html
+:text: PhD Students
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](communication/communication)
+- [](communication/comms-overview)
+- [](communication/comms-overview/comms-overview-principles)
+
+And more... 
+
+---
+```{link-button} ./group-leaders.html
+:text: Group Leaders
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](project-design/project-design)
+- [](project-design/pd-overview)
+- [](project-design/pd-overview/pd-overview-planning)
+
+And more... 
+
+---
+```{link-button} ./life-scientists.html
+:text: Life Scientists
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](reproducible-research/reproducible-research)
+- [](reproducible-research/overview)
+- [](reproducible-research/overview/overview-benefit)
+
+And more... 
+
+::: 
+
+:::{panels}
+:container: +full-width
+:column: col-lg-6 px-2 py-2
+:header: text-center bg-white
+:card: text-left shadow
+:footer: text-left
+```{link-button} ./data-study-group.html
+:text: Data Study Group
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](reproducible-research/reproducible-research)
+- [](reproducible-research/overview)
+- [](reproducible-research/overview/overview-resources)
+
+And more... 
+
+---
+```{link-button} ./phd-students.html
+:text: PhD Students
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](communication/communication)
+- [](communication/comms-overview)
+- [](communication/comms-overview/comms-overview-principles)
+
+And more... 
+
+---
+```{link-button} ./group-leaders.html
+:text: Group Leaders
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](project-design/project-design)
+- [](project-design/pd-overview)
+- [](project-design/pd-overview/pd-overview-planning)
+
+And more... 
+
+---
+```{link-button} ./life-scientists.html
+:text: Life Scientists
+:classes: bg-info text-white text-center font-weight-bold
+```
+^^^
+- [](reproducible-research/reproducible-research)
+- [](reproducible-research/overview)
+- [](reproducible-research/overview/overview-benefit)
+
+And more... 
+
+::: 
+
+
+
+(welcome-community)=
+## Our Community
+
+_The Turing Way_ community is dedicated to making collaborative, reusable and transparent research "too easy not to do".
+That means investing in the socio-technical skills required to work in a team, to build something more significant than any individual could deliver alone.
+
+_The Turing Way_ is:
+
+* a book
+* a community
+* a global collaboration
+
+We hope you find the content in the book helpful.
+Everything here is available for free under a [CC-BY licence](https://github.com/alan-turing-institute/the-turing-way/blob/master/LICENSE.md).
+Please use and re-use whatever you need, for any purpose.
+
+The book is collaboratively written and open from the start.
+To make this project truly accessible and useful for everyone, we invite you to contribute your skills and bring your perspectives into this project.
+To join this community, please read our [contribution guidelines](https://github.com/alan-turing-institute/the-turing-way/blob/master/CONTRIBUTING.md) and ways to [get in touch](https://github.com/alan-turing-institute/the-turing-way#get-in-touch).
+More information about the community and the project is available in the {ref}`ch`.
+We look forward to expanding and building _The Turing Way_ together.
+
+```{figure} figures/theturingway-chapters.jpg
+---
+name: theturingway-chapters
+alt: The Turing Way Guide to reproducible research and it's stucture illustrated to show a set of doors to represent how it's built on chapters and sub chapters of the different areas of the guide
+---
+_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300.
+```
+
+Although _The Turing Way_ receives support and funding from [The Alan Turing Institute](https://www.turing.ac.uk/), the project is designed to be a global collaboration.
+We have contributions from across the UK, and from India, Mexico, Australia, USA, and many European countries.
+Chapters have been written, reviewed and curated by members of research institutes and universities, government departments, and industry.
+We are committed to creating a space where people with diverse expertise and lived experiences can share their knowledge with others to allow us all to use data science to improve the world.
+
+We value the participation of every member of our community and want to ensure that every contributor has an enjoyable and fulfilling experience.
+Accordingly, everyone who participates in _The Turing Way_ project is expected to show respect and courtesy to other community members at all times.
+All contributions must abide by our [code of conduct](https://github.com/alan-turing-institute/the-turing-way/blob/master/CODE_OF_CONDUCT.md).
+
+![Gif showing screen capture of contributors table, smiling faces and emojis representing the types of contributions in a table](https://media.giphy.com/media/gKIUisnjpj2PS75nOJ/giphy.gif)
+
+(welcome-history)=
+## History
+
+The book started in January 2019 as a guide for reproducibility, covering {ref}`rr-vcs`, {ref}`rr-testing`, and {ref}`rr-ci`. However, technical skills are just one aspect of making data science research "open for all" and so in February 2020, _The Turing Way_ expanded into a series of guides: {ref}`rr`, {ref}`pd`, {ref}`cm`, {ref}`cl`, and {ref}`er`.
+
+(welcome-citing)=
+## Citing _The Turing Way_
+
+All material in _The Turing Way_ is available under a [CC-BY 4.0 licence](https://github.com/alan-turing-institute/the-turing-way/blob/master/LICENSE.md).
+
+You can cite _The Turing Way_ through the project's Zenodo archive using DOI: [10.5281/zenodo.3233853](https://doi.org/10.5281/zenodo.3233853).
+
+The citation will look something like:
+
+> The Turing Way Community, Becky Arnold, Louise Bowler, Sarah Gibson, Patricia Herterich, Rosie Higman, … Kirstie Whitaker. (2019, March 25). The Turing Way: A Handbook for Reproducible Data Science (Version v0.0.4). Zenodo. http://doi.org/10.5281/zenodo.3233986
+
+Please visit the [DOI link](https://doi.org/10.5281/zenodo.3233853) though to get the most recent version - the one above is not automatically generated and may be out of date.
+DOIs allow us to archive the repository and are useful for tracking the work in academic publications.
+
+You can also share the human-readable URL to a page in the book, for example, {ref}`https://the-turing-way.netlify.app/reproducible-research/overview/overview-definitions.html <rr-overview-definitions>`, but be aware that the project is under development and these links may change over time.
+You might want to include a [web archive link](http://web.archive.org), such as: [https://web.archive.org/web/20191030093753/https://the-turing-way.netlify.com/reproducibility/03/definitions.html](https://web.archive.org/web/20191030093753/https://the-turing-way.netlify.com/reproducibility/03/definitions.html), to make sure that you do not end up with broken links everywhere!
+
+We really appreciate any references that you make to _The Turing Way_ project in your work, and we hope it is useful.
+If you have any questions, please [get in touch](https://github.com/alan-turing-institute/the-turing-way#get-in-touch).

--- a/pathways/pathways/badge.py
+++ b/pathways/pathways/badge.py
@@ -6,32 +6,40 @@ import urllib
 def generate_badge(profile_name, colour, landing_name):
     """Return some badge markdown and a list of files to insert it into."""
 
-    url = generate_shields_link(profile_name, colour)
-    landing_page = "{0}.md".format(landing_name)
-    markdown = f"[![]({url})](/{landing_page})"
+    url = generate_shields_link()
+    #landing_page = "{0}.md".format(landing_name)
+    markdown = f"[![]({url})]()"
     return markdown
 
-
-def generate_shields_link(profile_name, colour):
+def generate_shields_link():
     """Generate a https://shields.io/ URL for this profile."""
 
     url = (
         "https://img.shields.io/static/v1"
         "?label=pathway"
-        f"&message={urllib.parse.quote(profile_name)}"
-        f"&color={colour}"
+        "&message=text"
     )
     return url
 
 
 def insert_badges(book_path, badges, profiles):
+   # print(profiles["files"])
     """Insert badges into the files specified by profiles."""
 
     # By using make_badge_dict(), we only need to open each file once
     badge_dict = make_badge_dict(badges, profiles)
 
     for key, value in badge_dict.items():
-        # value is a list of badges and key is a filename
+        code ="""<script> 
+        const images = document.querySelectorAll('img[src="https://img.shields.io/static/v1?label=pathway&message=text"]');
+        const urlSearchParams = new URLSearchParams(window.location.search);
+        const pathwayValue = urlSearchParams.get('pathway');
+        for (let i = 0; i <= images.length; i++) {
+        images[i].setAttribute('src', `https://img.shields.io/static/v1?label=pathway&message=${pathwayValue}`);
+       }
+
+        </script>
+        """
         with open(book_path / (key + ".md"), "r", encoding="utf-8") as f:
             text = f.read()
 
@@ -39,6 +47,7 @@ def insert_badges(book_path, badges, profiles):
 
         with open(book_path / (key + ".md"), "w", encoding="utf-8") as f:
             f.write(text)
+            f.write(code)
 
 
 def edit_text(badges, text):
@@ -57,14 +66,9 @@ def edit_text(badges, text):
 def make_badge_dict(badges, profiles):
     """Make a dict of files and their badges."""
     badge_dict = dict()
-
-    for badge, profile in zip(badges, profiles):
+    for profile in profiles:
         for filename in profile["files"]:
-            if filename in badge_dict:
-                entry = badge_dict[filename]
-                entry.append(badge)
-
-            else:
-                badge_dict[filename] = [badge]
+            if filename not in badge_dict:
+                badge_dict[filename] = ['[![](https://img.shields.io/static/v1?label=pathway&message=text)]()']
 
     return badge_dict

--- a/pathways/pathways/badge.py
+++ b/pathways/pathways/badge.py
@@ -33,39 +33,6 @@ def insert_badges(book_path, badges, profiles):
     badge_dict= make_badge_dict(badges, profiles)
 
     for key, value in badge_dict.items():
-        code = """<script>
-    const images = document.querySelectorAll('img[src^="https://img.shields.io/static/v1?label=pathway"]');
-    const urlSearchParams = new URLSearchParams(window.location.search);
-    const pathwayValue = urlSearchParams.get('pathway');
-    let landingName = pathwayValue.split(' ').join('-');
-    let colour = "blue";
-   
-
-    if (pathwayValue === "data study group") {
-        colour = "white";
-    } else if (pathwayValue === "phd students") {
-        colour = "blue";
-    } else if (pathwayValue === "group leaders") {
-        colour = "purple";
-    } else {
-        colour = "green";
-    }
-
-    if (pathwayValue !== null) {
-        var landingPage = pathwayValue.replace(/ /g, "-");
-        for (let i = 0; i < images.length; i++) {
-            if (i > 0) {
-                images[i].remove();
-            } else {
-                images[i].setAttribute('src', `https://img.shields.io/static/v1?label=pathway&message=${pathwayValue}&color=${colour}`);
-                const parent = images[i].closest('a');
-                parent.href= "../" + landingPage + ".html";
-
-              }
-          }
-        }
-    </script>
-  """
 
         with open(book_path / (key + ".md"), "r", encoding="utf-8") as f:
             text = f.read()
@@ -73,8 +40,7 @@ def insert_badges(book_path, badges, profiles):
         text = edit_text(value, text)
 
         with open(book_path / (key + ".md"), "w", encoding="utf-8") as f:
-            f.write(text)
-            f.write(code)
+            f.write(text)       
 
 
 def edit_text(badges, text):

--- a/pathways/pathways/landing_page.py
+++ b/pathways/pathways/landing_page.py
@@ -100,7 +100,7 @@ class LandingPage:
 
     def write_content(self):
         code = '''<script> 
-                const links = document.querySelectorAll('a');
+                const links = document.querySelectorAll('#main-content a');
                 const path = decodeURIComponent(window.location.pathname);
                 const groups = path.split("/");
                 const groupName = groups[groups.length - 1].replace(/\.html$/, "").replace(/-/g, " ");

--- a/pathways/pathways/landing_page.py
+++ b/pathways/pathways/landing_page.py
@@ -99,6 +99,19 @@ class LandingPage:
         return header_content
 
     def write_content(self):
+        code = '''<script> 
+                const links = document.querySelectorAll('a');
+                const path = decodeURIComponent(window.location.pathname);
+                const groups = path.split("/");
+                const groupName = groups[groups.length - 1].replace(/\.html$/, "").replace(/-/g, " ");
+                links.forEach(link => {
+                const href = link.getAttribute('href');
+                const url = new URL(href, window.location.href);
+                url.searchParams.set('pathway', groupName);
+                link.setAttribute('href', url.href);
+                });
+                </script>
+                '''
         """Populate landing page with curated toc"""
         self.md_file.new_header(
             level=1, title=self.persona , add_table_of_contents="n"
@@ -110,6 +123,7 @@ class LandingPage:
         )
         self.md_file.new_paragraph(intro_paragraph)
         self.md_file.new_list(self.curated_links)
+        self.md_file.write(code)
         self.md_file.create_md_file()
 
         return self.md_file.file_data_text

--- a/pathways/pathways/landing_page.py
+++ b/pathways/pathways/landing_page.py
@@ -99,20 +99,6 @@ class LandingPage:
         return header_content
 
     def write_content(self):
-        code = '''<script> 
-                const links = document.querySelectorAll('#main-content a');
-                const path = decodeURIComponent(window.location.pathname);
-                const groups = path.split("/");
-                const groupName = groups[groups.length - 1].replace(/\.html$/, "").replace(/-/g, " ");
-                links.forEach(link => {
-                const href = link.getAttribute('href');
-                const url = new URL(href, window.location.href);
-                url.searchParams.set('pathway', groupName);
-                link.setAttribute('href', url.href);
-                });
-                </script>
-                '''
-        """Populate landing page with curated toc"""
         self.md_file.new_header(
             level=1, title=self.persona , add_table_of_contents="n"
         )
@@ -123,7 +109,6 @@ class LandingPage:
         )
         self.md_file.new_paragraph(intro_paragraph)
         self.md_file.new_list(self.curated_links)
-        self.md_file.write(code)
         self.md_file.create_md_file()
 
         return self.md_file.file_data_text

--- a/pathways/pathways/main.py
+++ b/pathways/pathways/main.py
@@ -77,9 +77,9 @@ def pathways(book_path):
                 generate_toc(toc, profile),
                 landing_name,
                 profile["description"],
-            )
+            ))
         
-    insert_cards(new_path / "index.md", cards)
+    insert_cards(book_path / "index.md", cards)
     insert_landing_pages(landing_pages)
     insert_badges(book_path, badges, profiles)
 

--- a/pathways/pathways/main.py
+++ b/pathways/pathways/main.py
@@ -56,11 +56,11 @@ def pathways(book_path):
     """Add extra pathways to the book."""
 
     # The contents of _toc.yml and profiles.yml contents
-    new_path = book_path.parent / (book_path.name + "_copy")
-    copytree(book_path, new_path, dirs_exist_ok=True)
+    #new_path = book_path.parent / (book_path.name + "_copy")
+    #copytree(book_path, new_path, dirs_exist_ok=True)
 
-    landing_page.LandingPage.book_path = new_path
-    toc, profiles = get_toc_and_profiles(new_path)
+    landing_page.LandingPage.book_path = book_path
+    toc, profiles = get_toc_and_profiles(book_path)
 
     landing_pages = []
     badges = []
@@ -80,11 +80,11 @@ def pathways(book_path):
             )
         )
 
-    insert_cards(new_path / "welcome.md", cards)
+    insert_cards(book_path / "welcome.md", cards)
     insert_landing_pages(landing_pages)
-    insert_badges(new_path, badges, profiles)
+    insert_badges(book_path, badges, profiles)
 
-    run(["jupyter-book", "build", new_path], check=True)
+    run(["jupyter-book", "build", book_path], check=True)
     # rmtree(new_path)
 
     print("Finished adding pathways.")


### PR DESCRIPTION
## Summary 

When you visit a chapter within a profile specific page, you will see that all profile tag/labels where this chapter is selected (the same chapter can be curated for multiple profiles) appears on the top of the page as shown below. 


<img src="https://user-images.githubusercontent.com/5370471/157556414-cd5e90b5-407c-445d-ad9f-99d41f3f0d65.png"  width="700" height="200" />

\
The implementation aims to address this issue by only showing the original profile (clicked by the user ) at the top, while hiding the tags associated with other profiles. This change will enhance the browsing experience and reduce confusion.

## List of changes made 
- Modified chapter links on the profile page using JavaScript by adding a "pathway" search parameter with the selected profile name.
- Updated profile tags using JavaScript to display only the original profile selected by the user.

## What should a reviewer concentrate their feedback on?
- Does the implementation help in improving the user interface and user experience?
- Are there any errors or problems?
- Any suggestions to make it better? 






